### PR TITLE
[Reviewer: Rob] Support IPv6 hosts

### DIFF
--- a/lib/sip_parser.rb
+++ b/lib/sip_parser.rb
@@ -153,8 +153,17 @@ module Quaff
       Concat.new(user, Char.new(?@))
     end
 
+    def ipv6address
+      # Need to allow . as [ff::127.0.0.1] is valid according to RFC 3261
+      Repetition.new([:at_least, 1], Alternate.new(HexDigit.new, AlternateChars.new(".:")))
+    end
+
+    def ipv6reference
+      Concat.new(Char.new(?[), ipv6address, Char.new(?]))
+    end
+
     def hostname
-      Repetition.new([:at_least, 1], Alternate.new(alphanum, Char.new(?.), Char.new(?-)))
+      Alternate.new(ipv6reference, Repetition.new([:at_least, 1], Alternate.new(alphanum, Char.new(?.), Char.new(?-))))
     end
 
     def port


### PR DESCRIPTION
Currenty, quaff doesn't understand IPv6 hostnames which may appear in To tags.

We get a request with a To header such as:

```
To: <sip:7700000000@[fd5f:5d21:845:1402:250:56ff:fe92:3c14]>
```

but we don't understand the IPv6 hostname, so the parser fails, so we respond with:

```
To:  <>;tag=dcc062c088725ecea1c7634bb171bcb1
```

which obviously causes the call to fail.

I've added a fairly weak interpretation of the SIP ABNF spec for IPv6 - specifically I haven't cared about making sure that the IPv6 address is particularly well formed (e.g. `fff::ff::f` will pass, despite being ill-formed). I think this is similar to our current understanding of hostnames, and so is acceptable.